### PR TITLE
Use bevy render target in wgpu backend

### DIFF
--- a/inox2d-bevy/src/lib.rs
+++ b/inox2d-bevy/src/lib.rs
@@ -2,6 +2,7 @@ use bevy::asset::AssetLoader;
 use bevy::prelude::*;
 use bevy::reflect::TypePath;
 use bevy::render::renderer::{RenderDevice, RenderQueue};
+use bevy::render::view::ViewTarget;
 use futures_lite::future::block_on;
 use inox2d::formats::inp::{parse_inp, ParseInpError};
 use inox2d::model::Model;
@@ -96,10 +97,16 @@ pub fn update_puppets(
         }
 }
 
-pub fn draw_puppets(assets: Res<Assets<InoxAsset>>, query: Query<(&InoxModelHandle, &InoxWgpuRenderer)>) {
-	for (handle, renderer) in &query {
-		if let Some(model) = assets.get(&handle.0) {
-			renderer.0.draw(&model.0.puppet);
-		}
-	}
+pub fn draw_puppets(
+        assets: Res<Assets<InoxAsset>>,
+        targets: Query<&ViewTarget>,
+        query: Query<(&InoxModelHandle, &InoxWgpuRenderer)>,
+) {
+        let Ok(view_target) = targets.get_single() else { return; };
+        for (handle, renderer) in &query {
+                if let Some(model) = assets.get(&handle.0) {
+                        renderer.0.set_target_view(view_target.out_texture());
+                        renderer.0.draw(&model.0.puppet);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- remove dummy texture from wgpu renderer
- allow setting a render target view each frame
- draw to the view from Bevy's `ViewTarget`

## Testing
- `cargo test` *(fails: build aborted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687d278d3490833192cccd7ddaa19e0f