### PR TITLE
Integrate Inox2d drawing into Bevy render phase

### DIFF
--- a/inox2d-wgpu/src/lib.rs
+++ b/inox2d-wgpu/src/lib.rs
@@ -79,6 +79,13 @@ pub struct WgpuRenderer {
     pub viewport: UVec2,
 }
 
+// WgpuRenderer interacts exclusively with the render thread. The underlying
+// wgpu types are thread-safe, but interior pointers stored in `Cell` and
+// `RefCell` mean the compiler can't automatically prove Send/Sync. Rendering
+// occurs on a single thread, so declaring these as safe is acceptable here.
+unsafe impl Send for WgpuRenderer {}
+unsafe impl Sync for WgpuRenderer {}
+
 impl WgpuRenderer {
     pub fn new(device: wgpu::Device, queue: wgpu::Queue, model: &Model) -> Result<Self, WgpuRendererError> {
         let verts = model


### PR DESCRIPTION
## Summary
- expose Bevy render schedule and run draw system there
- access main world data from the render app
- allow `WgpuRenderer` to be `Send` and `Sync` so it can be stored as a component

## Testing
- `cargo check --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_687d5bc1b4048331bfc340c65c0bcbb9