### PR TITLE
Add standalone wgpu example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,11 @@ resolver = "2"
 members = [
     "inox2d",
     "inox2d-opengl",
-    "examples/*",
     "inox2d-wgpu",
     "inox2d-bevy",
+    "examples/common",
+    "examples/render-bevy",
+    "examples/render-opengl",
+    "examples/render-webgl",
+    "examples/render-wgpu",
 ]

--- a/examples/render-wgpu/Cargo.toml
+++ b/examples/render-wgpu/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "render-wgpu"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+common = { path = "../common" }
+inox2d = { path = "../../inox2d" }
+inox2d-wgpu = { path = "../../inox2d-wgpu" }
+
+clap = { version = "4.1.8", features = ["derive"] }
+wgpu = "24"
+winit = { version = "0.29", features = ["rwh_05"] }
+glam = { version = "0.29.0", features = ["bytemuck"] }
+pollster = "0.3"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"

--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -1,0 +1,164 @@
+use std::path::PathBuf;
+use std::{error::Error, fs};
+
+use clap::Parser;
+use glam::Vec2;
+use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
+
+use wgpu::{Surface, SurfaceConfiguration};
+use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
+use winit::event_loop::EventLoop;
+use winit::keyboard::{KeyCode, PhysicalKey};
+use winit::window::{Window, WindowBuilder};
+
+use common::scene::ExampleSceneController;
+use inox2d::formats::inp::parse_inp;
+use inox2d::render::InoxRendererExt;
+use inox2d_wgpu::WgpuRenderer;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+	#[arg(help = "Path to the .inp or .inx file.")]
+	inp_path: PathBuf,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+	pollster::block_on(run())
+}
+
+async fn init_wgpu(
+	window: &Window,
+) -> Result<(Surface, wgpu::Device, wgpu::Queue, SurfaceConfiguration), Box<dyn Error>> {
+	let size = window.inner_size();
+	let instance = wgpu::Instance::default();
+	let surface = unsafe { instance.create_surface(window)? };
+	let adapter = instance
+		.request_adapter(&wgpu::RequestAdapterOptions {
+			power_preference: wgpu::PowerPreference::HighPerformance,
+			compatible_surface: Some(&surface),
+			force_fallback_adapter: false,
+		})
+		.await
+		.ok_or("Failed to find an adapter")?;
+	let (device, queue) = adapter.request_device(&wgpu::DeviceDescriptor::default(), None).await?;
+	let caps = surface.get_capabilities(&adapter);
+	let format = caps
+		.formats
+		.iter()
+		.copied()
+		.find(|f| f.is_srgb())
+		.unwrap_or(caps.formats[0]);
+	let config = SurfaceConfiguration {
+		usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+		format,
+		width: size.width.max(1),
+		height: size.height.max(1),
+		present_mode: wgpu::PresentMode::Fifo,
+		desired_maximum_frame_latency: 2,
+		alpha_mode: caps.alpha_modes[0],
+		view_formats: vec![],
+	};
+	surface.configure(&device, &config);
+	Ok((surface, device, queue, config))
+}
+
+async fn run() -> Result<(), Box<dyn Error>> {
+	let cli = Cli::parse();
+
+	tracing_subscriber::registry()
+		.with(fmt::layer())
+		.with(LevelFilter::INFO)
+		.init();
+
+	tracing::info!("Parsing puppet");
+	let data = fs::read(cli.inp_path)?;
+	let mut model = parse_inp(data.as_slice())?;
+	tracing::info!(
+		"Successfully parsed puppet: {}",
+		(model.puppet.meta.name.as_deref()).unwrap_or("<no puppet name specified in file>")
+	);
+
+	tracing::info!("Setting up puppet for transforms, params and rendering.");
+	model.puppet.init_transforms();
+	model.puppet.init_rendering();
+	model.puppet.init_params();
+	model.puppet.init_physics();
+
+	tracing::info!("Setting up windowing and WGPU");
+	let event_loop = EventLoop::new()?;
+	let window = WindowBuilder::new()
+		.with_transparent(true)
+		.with_resizable(true)
+		.with_inner_size(winit::dpi::PhysicalSize::new(600, 800))
+		.with_title("Render Inochi2D Puppet (WGPU)")
+		.build(&event_loop)?;
+
+	// Leak the window so the surface can outlive the original binding.
+	let window: &'static Window = Box::leak(Box::new(window));
+
+	let (surface, device, queue, mut surface_config) = init_wgpu(window).await?;
+	let mut renderer = WgpuRenderer::new(device.clone(), queue.clone(), &model)?;
+	renderer.resize(surface_config.width, surface_config.height);
+	renderer.camera.scale = Vec2::splat(0.15);
+
+	let mut scene_ctrl = ExampleSceneController::new(&renderer.camera, 0.5);
+
+	event_loop.run(move |event, elwt| match event {
+		Event::WindowEvent { event, .. } => match event {
+			WindowEvent::Resized(size) => {
+				surface_config.width = size.width.max(1);
+				surface_config.height = size.height.max(1);
+				surface.configure(&device, &surface_config);
+				renderer.resize(surface_config.width, surface_config.height);
+			}
+			WindowEvent::CloseRequested => elwt.exit(),
+			WindowEvent::KeyboardInput {
+				event:
+					KeyEvent {
+						state: ElementState::Pressed,
+						physical_key: PhysicalKey::Code(KeyCode::Escape),
+						..
+					},
+				..
+			} => elwt.exit(),
+			e => scene_ctrl.interact(&e, &renderer.camera),
+		},
+		Event::AboutToWait => {
+			scene_ctrl.update(&mut renderer.camera);
+
+			let puppet = &mut model.puppet;
+			puppet.begin_frame();
+			let t = scene_ctrl.current_elapsed();
+			let _ = puppet
+				.param_ctx
+				.as_mut()
+				.unwrap()
+				.set("Head:: Yaw-Pitch", Vec2::new(t.cos(), t.sin()));
+			puppet.end_frame(scene_ctrl.dt());
+
+			let frame = match surface.get_current_texture() {
+				Ok(f) => f,
+				Err(wgpu::SurfaceError::Outdated) => {
+					surface.configure(&device, &surface_config);
+					surface.get_current_texture().unwrap()
+				}
+				Err(e) => {
+					tracing::error!("Surface error: {:?}", e);
+					elwt.exit();
+					return;
+				}
+			};
+			let view = frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
+			renderer.set_target_view(&view);
+			renderer.on_begin_draw(puppet);
+			renderer.draw(puppet);
+			renderer.on_end_draw(puppet);
+			frame.present();
+			window.request_redraw();
+		}
+		_ => {}
+	})?;
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary
- add new `render-wgpu` example using `wgpu` and `winit`
- configure workspace members explicitly

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687f6580eb208331bb8121973ec8ad8d