### PR TITLE
Add example helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ plugin will apply them each frame.
 
 See [`examples/render-bevy`](/examples/render-bevy) for a minimal setup.
 
+### Running the examples
+
+This repository includes a helper script that downloads the official example
+models and runs any of the example crates. The models are fetched the first time
+the script is executed.
+
+```sh
+./run_example.sh render-opengl Aka
+```
+
 ## Implementation
 
 Inox2D aims to support all features currently present in the standard D implementation.

--- a/run_example.sh
+++ b/run_example.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Helper script to run Inox2D examples with sample models
+set -e
+
+REPO_URL="https://github.com/Inochi2D/example-models"
+MODELS_DIR="examples/example-models"
+
+usage() {
+    echo "Usage: $0 <example-crate> [ModelName] [-- <extra cargo args>]"
+    echo "  example-crate: render-opengl | render-wgpu | render-bevy | render-webgl"
+    echo "  ModelName:    Aka | Midori (default: Aka)"
+    exit 1
+}
+
+[ -z "$1" ] && usage
+EXAMPLE="$1"; shift
+MODEL="${1:-Aka}"
+[ $# -gt 0 ] && shift
+
+if [ ! -d "$MODELS_DIR" ]; then
+    echo "Cloning example models..."
+    git clone "$REPO_URL" "$MODELS_DIR"
+    (cd "$MODELS_DIR" && git lfs pull)
+fi
+
+MODEL_PATH="$MODELS_DIR/${MODEL}.inx"
+if [ ! -f "$MODEL_PATH" ]; then
+    echo "Model $MODEL_PATH not found. Available models:"
+    ls "$MODELS_DIR"/*.inx | xargs -n1 basename | sed 's/\.inx$//'
+    exit 1
+fi
+
+case "$EXAMPLE" in
+    render-webgl)
+        # WebGL example runs with trunk
+        (cd examples/render-webgl && trunk serve "$@")
+        ;;
+    *)
+        cargo run -p "$EXAMPLE" -- "$MODEL_PATH" "$@"
+        ;;
+esac
+


### PR DESCRIPTION
## Summary
- add `run_example.sh` script that fetches example models and runs an example
- document how to use the script in the README

## Testing
- `cargo fmt -- --check`
- `cargo check`
- `shellcheck run_example.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f759aee688331959593d49d5d563f