### PR TITLE
Add interactive camera control to Bevy example

### DIFF
--- a/examples/render-bevy/Cargo.toml
+++ b/examples/render-bevy/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 bevy = { version = "0.16", default-features = false, features = ["bevy_asset","bevy_winit","bevy_render","bevy_core_pipeline","x11"] }
 inox2d-bevy = { path = "../../inox2d-bevy" }
 inox2d = { path = "../../inox2d" }
+common = { path = "../common" }
+winit = { version = "0.29", features = ["rwh_05"] }
 
 [dependencies.glam]
 version = "0.29"

--- a/examples/render-bevy/src/main.rs
+++ b/examples/render-bevy/src/main.rs
@@ -1,28 +1,95 @@
 use bevy::core_pipeline::core_2d::Camera2d;
 use bevy::prelude::*;
+use common::scene::ExampleSceneController;
 use inox2d::math::camera::Camera as InoxCameraData;
 use inox2d_bevy::{Inox2dPlugin, InoxCamera, InoxModelHandle};
 use std::env;
+use winit::dpi::PhysicalPosition;
+use winit::event::{DeviceId, ElementState, MouseButton as WinitMouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
+use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
+use bevy::input::ButtonInput;
+use bevy::prelude::Resource;
 
-fn setup(mut commands: Commands, assets: Res<AssetServer>) {
-	commands.spawn(Camera2d);
-	let path = env::args().nth(1).expect("Usage: render-bevy <MODEL>");
-	let model: Handle<_> = assets.load(path);
+#[derive(Resource)]
+struct SceneController(ExampleSceneController);
+
+#[derive(Resource)]
+struct ModelPath(String);
+
+fn setup(mut commands: Commands, assets: Res<AssetServer>, path: Res<ModelPath>) {
+        commands.spawn(Camera2d);
+        let model: Handle<_> = assets.load(&path.0);
+        let camera = InoxCameraData {
+                scale: Vec2::splat(0.15),
+                ..Default::default()
+        };
         commands.spawn((
                 InoxModelHandle(model),
-                InoxCamera(InoxCameraData {
-                        scale: Vec2::splat(0.15),
-                        ..Default::default()
-                }),
+                InoxCamera(camera.clone()),
                 Transform::default(),
                 GlobalTransform::default(),
         ));
+        commands.insert_resource(SceneController(ExampleSceneController::new(&camera, 0.5)));
+}
+
+fn control_camera(
+        mut scene: ResMut<SceneController>,
+        mut camera_q: Query<&mut InoxCamera>,
+        buttons: Res<ButtonInput<MouseButton>>,
+        mut cursor_evr: EventReader<CursorMoved>,
+        mut wheel_evr: EventReader<MouseWheel>,
+) {
+        let mut camera = camera_q.single_mut().expect("InoxCamera missing");
+
+        for ev in cursor_evr.read() {
+                let wev = WindowEvent::CursorMoved {
+                        device_id: unsafe { DeviceId::dummy() },
+                        position: PhysicalPosition::new(ev.position.x as f64, ev.position.y as f64),
+                };
+                scene.0.interact(&wev, &camera.0);
+        }
+
+        if buttons.just_pressed(MouseButton::Left) {
+                let wev = WindowEvent::MouseInput {
+                        device_id: unsafe { DeviceId::dummy() },
+                        state: ElementState::Pressed,
+                        button: WinitMouseButton::Left,
+                };
+                scene.0.interact(&wev, &camera.0);
+        }
+
+        if buttons.just_released(MouseButton::Left) {
+                let wev = WindowEvent::MouseInput {
+                        device_id: unsafe { DeviceId::dummy() },
+                        state: ElementState::Released,
+                        button: WinitMouseButton::Left,
+                };
+                scene.0.interact(&wev, &camera.0);
+        }
+
+        for ev in wheel_evr.read() {
+                let delta = match ev.unit {
+                        MouseScrollUnit::Line => MouseScrollDelta::LineDelta(ev.x, ev.y),
+                        MouseScrollUnit::Pixel => MouseScrollDelta::PixelDelta(PhysicalPosition::new(ev.x as f64, ev.y as f64)),
+                };
+                let wev = WindowEvent::MouseWheel {
+                        device_id: unsafe { DeviceId::dummy() },
+                        delta,
+                        phase: TouchPhase::Moved,
+                };
+                scene.0.interact(&wev, &camera.0);
+        }
+
+        scene.0.update(&mut camera.0);
 }
 
 fn main() {
-	App::new()
-		.add_plugins(DefaultPlugins)
-		.add_plugins(Inox2dPlugin)
-		.add_systems(Startup, setup)
-		.run();
+        let path = env::args().nth(1).expect("Usage: render-bevy <MODEL>");
+        App::new()
+                .insert_resource(ModelPath(path))
+                .add_plugins(DefaultPlugins)
+                .add_plugins(Inox2dPlugin)
+                .add_systems(Startup, setup)
+                .add_systems(Update, control_camera)
+                .run();
 }


### PR DESCRIPTION
## Summary
- use `common` example crate in `render-bevy`
- update `render-bevy` to use `ExampleSceneController`
- translate Bevy input events to winit events and update `InoxCamera`
- parse command line arguments before starting the Bevy `App`

## Testing
- `cargo check --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_687f754f9bc88331a1cd64513a9433ca