### PR TITLE
Handle wgpu renderer init errors

### DIFF
--- a/inox2d-bevy/Cargo.toml
+++ b/inox2d-bevy/Cargo.toml
@@ -12,6 +12,7 @@ futures-lite = "2.6"
 # Use path to inox2d
 inox2d = { path = "../inox2d" }
 inox2d-wgpu = { path = "../inox2d-wgpu" }
+tracing = "0.1"
 
 [dependencies.glam]
 version = "0.29"


### PR DESCRIPTION
## Summary
- add `tracing` dependency for error logging
- emit a `RendererInitFailed` event and store the error on the entity
- log when a `WgpuRenderer` cannot be constructed

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687fac7d16d88331bacec8f66ec629a1