### PR TITLE
Fix bevy example and plugin

### DIFF
--- a/examples/render-bevy/src/main.rs
+++ b/examples/render-bevy/src/main.rs
@@ -39,7 +39,9 @@ fn control_camera(
         mut cursor_evr: EventReader<CursorMoved>,
         mut wheel_evr: EventReader<MouseWheel>,
 ) {
-        let mut camera = camera_q.single_mut().expect("InoxCamera missing");
+    let Ok(mut camera) = camera_q.single_mut() else {
+        return;
+    };
 
         for ev in cursor_evr.read() {
                 let wev = WindowEvent::CursorMoved {
@@ -84,7 +86,10 @@ fn control_camera(
 }
 
 fn main() {
-        let path = env::args().nth(1).expect("Usage: render-bevy <MODEL>");
+        let Some(path) = env::args().nth(1) else {
+                eprintln!("Usage: render-bevy <MODEL>");
+                std::process::exit(1);
+        };
         App::new()
                 .insert_resource(ModelPath(path))
                 .add_plugins(DefaultPlugins)

--- a/inox2d-bevy/src/lib.rs
+++ b/inox2d-bevy/src/lib.rs
@@ -73,9 +73,9 @@ impl Plugin for Inox2dPlugin {
 			.add_event::<RendererInitFailed>()
 			.add_systems(Update, (update_puppets, sync_inox_camera, sync_inox_render_config));
 
-		if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
-			render_app.add_systems(Render, draw_puppets.in_set(RenderSet::Render).after(RenderSet::Render));
-		}
+                if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+                        render_app.add_systems(Render, draw_puppets.in_set(RenderSet::Render));
+                }
 	}
 }
 #[derive(Component)]
@@ -163,7 +163,7 @@ pub fn update_puppets(
 						}
 						Err(e) => {
 							error!("failed to create WgpuRenderer: {}", e);
-							error_events.send(RendererInitFailed {
+                                                        error_events.write(RendererInitFailed {
 								entity,
 								error: e.to_string(),
 							});
@@ -184,13 +184,13 @@ pub fn update_puppets(
 }
 
 pub fn draw_puppets(mut main_world: ResMut<MainWorld>, targets: Query<&ViewTarget>) {
-	let Ok(view_target) = targets.get_single() else {
+    let Ok(view_target) = targets.single() else {
 		return;
 	};
 	let width = view_target.main_texture().width();
 	let height = view_target.main_texture().height();
 
-	main_world.resource_scope(|world, mut assets: Mut<Assets<InoxAsset>>| {
+    main_world.resource_scope(|world, assets: Mut<Assets<InoxAsset>>| {
 		let mut query = world.query::<(&InoxModelHandle, &mut InoxWgpuRenderer)>();
 		for (handle, mut renderer) in query.iter_mut(world) {
 			if let Some(model) = assets.get(&handle.0) {


### PR DESCRIPTION
## Summary
- avoid scheduling conflict in `Inox2dPlugin`
- fix deprecated methods and unused `mut`
- improve error handling in the Bevy example

## Testing
- `cargo check --all-targets`
- `cargo test --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_687fb1c2a54c8331868ff569081e24be