### PR TITLE
Fix wgpu example shader and remove deprecated APIs

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -32,7 +32,7 @@ async fn init_wgpu(
 ) -> Result<(Surface, wgpu::Device, wgpu::Queue, SurfaceConfiguration), Box<dyn Error>> {
 	let size = window.inner_size();
 	let instance = wgpu::Instance::default();
-	let surface = unsafe { instance.create_surface(window)? };
+    let surface = instance.create_surface(window)?;
 	let adapter = instance
 		.request_adapter(&wgpu::RequestAdapterOptions {
 			power_preference: wgpu::PowerPreference::HighPerformance,


### PR DESCRIPTION
## Summary
- fix WGSL shader syntax in `inox2d-wgpu`
- switch to `TexelCopyTextureInfo` and `TexelCopyBufferLayout`
- drop unused fields from `WgpuRenderer`
- remove unnecessary unsafe block in the wgpu example

## Testing
- `cargo build -p inox2d-wgpu --quiet`
- `cargo build --package render-wgpu --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687fbbbc0de88331994f509b104fc28f