### PR TITLE
Fix depth-stencil attachment for wgpu composite pass

### DIFF
--- a/inox2d-wgpu/src/lib.rs
+++ b/inox2d-wgpu/src/lib.rs
@@ -804,7 +804,14 @@ impl InoxRenderer for WgpuRenderer {
 						store: wgpu::StoreOp::Store,
 					},
 				})],
-				depth_stencil_attachment: None,
+                                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                                        view: &self.stencil_view,
+                                        depth_ops: None,
+                                        stencil_ops: Some(wgpu::Operations {
+                                                load: wgpu::LoadOp::Load,
+                                                store: wgpu::StoreOp::Store,
+                                        }),
+                                }),
 				timestamp_writes: None,
 				occlusion_query_set: None,
 			});
@@ -843,7 +850,14 @@ impl InoxRenderer for WgpuRenderer {
 						store: wgpu::StoreOp::Store,
 					},
 				})],
-				depth_stencil_attachment: None,
+                                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                                        view: &self.stencil_view,
+                                        depth_ops: None,
+                                        stencil_ops: Some(wgpu::Operations {
+                                                load: wgpu::LoadOp::Load,
+                                                store: wgpu::StoreOp::Store,
+                                        }),
+                                }),
 				timestamp_writes: None,
 				occlusion_query_set: None,
 			});


### PR DESCRIPTION
## Summary
- attach stencil buffer when clearing/compositing
- use the same stencil buffer when blending composite content

## Testing
- `cargo check -q`
- `./run_example.sh render-wgpu Aka -- -q` *(fails: curl stuck at 0%)*

------
https://chatgpt.com/codex/tasks/task_e_687fc36b89048331bf1dab7942d4d7e5