### PR TITLE
Improve WGPU renderer error diagnostics

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -97,9 +97,15 @@ async fn run() -> Result<(), Box<dyn Error>> {
 	// Leak the window so the surface can outlive the original binding.
 	let window: &'static Window = Box::leak(Box::new(window));
 
-	let (surface, device, queue, mut surface_config) = init_wgpu(window).await?;
-	let mut renderer = WgpuRenderer::new(device.clone(), queue.clone(), &model)?;
-	renderer.resize(surface_config.width, surface_config.height);
+        let (surface, device, queue, mut surface_config) = init_wgpu(window).await?;
+        device.on_uncaptured_error(Box::new(|e| {
+            tracing::error!("wgpu uncaptured error: {:?}", e);
+        }));
+
+        tracing::info!("Initializing Inox2D renderer");
+        let mut renderer = WgpuRenderer::new(device.clone(), queue.clone(), &model, surface_config.format)?;
+        tracing::info!("Inox2D renderer initialized");
+        renderer.resize(surface_config.width, surface_config.height);
 	renderer.camera.scale = Vec2::splat(0.15);
 
 	let mut scene_ctrl = ExampleSceneController::new(&renderer.camera, 0.5);

--- a/inox2d-bevy/src/lib.rs
+++ b/inox2d-bevy/src/lib.rs
@@ -154,7 +154,12 @@ pub fn update_puppets(
 			if renderer.is_none() {
 				if let (Some(device), Some(queue)) = (render_device.as_ref(), render_queue.as_ref()) {
 					let wgpu_queue = queue.0.as_ref().clone().into_inner();
-					match WgpuRenderer::new(device.wgpu_device().clone(), wgpu_queue, &model.0) {
+                                        match WgpuRenderer::new(
+                                                device.wgpu_device().clone(),
+                                                wgpu_queue,
+                                                &model.0,
+                                                bevy::render::render_resource::TextureFormat::Bgra8UnormSrgb,
+                                        ) {
 						Ok(r) => {
 							commands
 								.entity(entity)

--- a/inox2d-wgpu/Cargo.toml
+++ b/inox2d-wgpu/Cargo.toml
@@ -8,6 +8,7 @@ description = "WGPU renderer for Inox2D"
 wgpu = "24"
 thiserror = "1"
 bytemuck = { version = "1", features = ["derive"] }
+tracing = "0.1"
 
 inox2d = { path = "../inox2d" }
 


### PR DESCRIPTION
## Summary
- allow configuring the output surface format for `WgpuRenderer`
- log initialization progress and uncaptured WGPU errors
- pass surface format from the example and update Bevy integration

## Testing
- `cargo check --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_687fcd84cbc88331b6d48d56a7d6ff11