### PR TITLE
Fix wgpu surface format issue

### DIFF
--- a/inox2d-bevy/src/lib.rs
+++ b/inox2d-bevy/src/lib.rs
@@ -158,7 +158,7 @@ pub fn update_puppets(
                                                 device.wgpu_device().clone(),
                                                 wgpu_queue,
                                                 &model.0,
-                                                bevy::render::render_resource::TextureFormat::Bgra8UnormSrgb,
+                                                bevy::render::render_resource::TextureFormat::bevy_default(),
                                         ) {
 						Ok(r) => {
 							commands


### PR DESCRIPTION
## Summary
- use `bevy_default()` texture format when initializing the wgpu renderer in the Bevy plugin

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687fd12dd11c833187151c8cb36afc26