### PR TITLE
Fix Bevy example crash

### DIFF
--- a/examples/render-bevy/src/main.rs
+++ b/examples/render-bevy/src/main.rs
@@ -90,9 +90,11 @@ fn main() {
                 eprintln!("Usage: render-bevy <MODEL>");
                 std::process::exit(1);
         };
+        use bevy::render::pipelined_rendering::PipelinedRenderingPlugin;
+
         App::new()
                 .insert_resource(ModelPath(path))
-                .add_plugins(DefaultPlugins)
+                .add_plugins(DefaultPlugins.build().disable::<PipelinedRenderingPlugin>())
                 .add_plugins(Inox2dPlugin)
                 .add_systems(Startup, setup)
                 .add_systems(Update, control_camera)


### PR DESCRIPTION
## Summary
- disable Bevy's `PipelinedRenderingPlugin` to keep `MainWorld` available
  during rendering

## Testing
- `cargo check --package render-bevy`

------
https://chatgpt.com/codex/tasks/task_e_687fd63c31388331b70f7f313763a84b