### PR TITLE
Extract wgsl files for wgpu renderer

### DIFF
--- a/inox2d-wgpu/Cargo.toml
+++ b/inox2d-wgpu/Cargo.toml
@@ -9,6 +9,7 @@ wgpu = "24"
 thiserror = "1"
 bytemuck = { version = "1", features = ["derive"] }
 tracing = "0.1"
+include-wgsl-oil = "0.2"
 
 inox2d = { path = "../inox2d" }
 

--- a/inox2d-wgpu/src/shaders.rs
+++ b/inox2d-wgpu/src/shaders.rs
@@ -1,0 +1,8 @@
+#[include_wgsl_oil::include_wgsl_oil("shaders/vertex.wgsl")]
+pub mod vertex {}
+
+#[include_wgsl_oil::include_wgsl_oil("shaders/fragment.wgsl")]
+pub mod fragment {}
+
+#[include_wgsl_oil::include_wgsl_oil("shaders/mask.wgsl")]
+pub mod mask {}

--- a/inox2d-wgpu/src/shaders/fragment.wgsl
+++ b/inox2d-wgpu/src/shaders/fragment.wgsl
@@ -1,0 +1,26 @@
+struct VertexOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+struct FragUniform {
+    mult_color: vec4<f32>,
+    screen_color: vec4<f32>,
+    params: vec4<f32>,
+};
+@group(1) @binding(0) var samp: sampler;
+@group(1) @binding(1) var tex_albedo: texture_2d<f32>;
+@group(1) @binding(2) var tex_emissive: texture_2d<f32>;
+@group(1) @binding(3) var tex_bump: texture_2d<f32>;
+@group(2) @binding(0) var<uniform> frag: FragUniform;
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    let tex_color = textureSample(tex_albedo, samp, in.uv);
+    let screen_out = vec3<f32>(1.0) - ((vec3<f32>(1.0) - tex_color.xyz) * (vec3<f32>(1.0) - (frag.screen_color.xyz * tex_color.a)));
+    var base = vec4<f32>(screen_out, tex_color.a) * frag.mult_color * frag.params.x;
+    let emissive = textureSample(tex_emissive, samp, in.uv).xyz * frag.params.y * base.a;
+    let _bump = textureSample(tex_bump, samp, in.uv); // currently unused
+    base = vec4<f32>(base.xyz + emissive, base.a);
+    return base;
+}

--- a/inox2d-wgpu/src/shaders/mask.wgsl
+++ b/inox2d-wgpu/src/shaders/mask.wgsl
@@ -1,0 +1,19 @@
+struct VertexOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@group(1) @binding(0) var samp: sampler;
+@group(1) @binding(1) var tex_albedo: texture_2d<f32>;
+
+struct MaskUniform { threshold: f32, };
+@group(2) @binding(0) var<uniform> mask: MaskUniform;
+
+@fragment
+fn fs_mask(in: VertexOut) -> @location(0) vec4<f32> {
+    let color = textureSample(tex_albedo, samp, in.uv);
+    if (color.a <= mask.threshold) {
+        discard;
+    }
+    return vec4<f32>(1.0);
+}

--- a/inox2d-wgpu/src/shaders/vertex.wgsl
+++ b/inox2d-wgpu/src/shaders/vertex.wgsl
@@ -1,0 +1,30 @@
+struct CameraUniform { mvp: mat4x4<f32>, };
+@group(0) @binding(0) var<uniform> camera: CameraUniform;
+@group(1) @binding(0) var samp: sampler;
+@group(1) @binding(1) var tex_albedo: texture_2d<f32>;
+@group(1) @binding(2) var tex_emissive: texture_2d<f32>;
+@group(1) @binding(3) var tex_bump: texture_2d<f32>;
+
+struct VertexIn {
+    @location(0) pos: vec2<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) deform: vec2<f32>,
+};
+struct VertexOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+struct FragUniform {
+    mult_color: vec4<f32>,
+    screen_color: vec4<f32>,
+    params: vec4<f32>,
+};
+
+@vertex
+fn vs_main(v: VertexIn) -> VertexOut {
+    var out: VertexOut;
+    out.pos = camera.mvp * vec4<f32>(v.pos + v.deform, 0.0, 1.0);
+    out.uv = v.uv;
+    return out;
+}


### PR DESCRIPTION
## Summary
- move shader source strings in `inox2d-wgpu` into their own wgsl files
- include them at compile time using `include-wgsl-oil`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687fdc1a6eec833186c68b149601cb76