### PR TITLE
Add mesh origin uniform to wgpu pipeline

### DIFF
--- a/inox2d-wgpu/src/shaders/vertex.wgsl
+++ b/inox2d-wgpu/src/shaders/vertex.wgsl
@@ -2,6 +2,8 @@ struct CameraUniform { mvp: mat4x4<f32>, };
 @group(0) @binding(0) var<uniform> camera: CameraUniform;
 struct TransformUniform { mvp: mat4x4<f32>, };
 @group(3) @binding(0) var<uniform> transform: TransformUniform;
+struct OriginUniform { origin: vec2<f32>, };
+@group(4) @binding(0) var<uniform> origin: OriginUniform;
 @group(1) @binding(0) var samp: sampler;
 @group(1) @binding(1) var tex_albedo: texture_2d<f32>;
 @group(1) @binding(2) var tex_emissive: texture_2d<f32>;
@@ -26,7 +28,7 @@ struct FragUniform {
 @vertex
 fn vs_main(v: VertexIn) -> VertexOut {
     var out: VertexOut;
-    out.pos = transform.mvp * vec4<f32>(v.pos + v.deform, 0.0, 1.0);
+    out.pos = transform.mvp * vec4<f32>(v.pos - origin.origin + v.deform, 0.0, 1.0);
     out.uv = v.uv;
     return out;
 }


### PR DESCRIPTION
## Summary
- add new origin uniform to the vertex shader
- store mesh origin in a buffer/bind group
- bind origin in render passes and include layout in pipeline creation

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687fea051d7c83319a35698fc1b1bd31