### PR TITLE
Fix wgpu example validation errors

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -41,7 +41,20 @@ async fn init_wgpu(
 		})
 		.await
 		.ok_or("Failed to find an adapter")?;
-	let (device, queue) = adapter.request_device(&wgpu::DeviceDescriptor::default(), None).await?;
+	let limits = wgpu::Limits {
+		max_bind_groups: 5,
+		..wgpu::Limits::default()
+	};
+	let (device, queue) = adapter
+		.request_device(
+			&wgpu::DeviceDescriptor {
+				required_features: wgpu::Features::empty(),
+				required_limits: limits,
+				..Default::default()
+			},
+			None,
+		)
+		.await?;
 	let caps = surface.get_capabilities(&adapter);
 	let format = caps
 		.formats


### PR DESCRIPTION
## Summary
- adjust `request_device` limits in the wgpu example

## Testing
- `cargo check -p render-wgpu`

------
https://chatgpt.com/codex/tasks/task_e_687fed4811948331b734bd9025821ba5