### PR TITLE
Enable runtime logging config in wgpu example

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -3,7 +3,8 @@ use std::{error::Error, fs};
 
 use clap::Parser;
 use glam::Vec2;
-use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use wgpu::{Surface, SurfaceConfiguration};
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
@@ -98,7 +99,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
 
 	tracing_subscriber::registry()
 		.with(fmt::layer())
-		.with(LevelFilter::INFO)
+		.with(EnvFilter::from_default_env().add_directive(LevelFilter::INFO.into()))
 		.init();
 
 	tracing::info!("Parsing puppet");


### PR DESCRIPTION
## Summary
- use `EnvFilter` so `RUST_LOG` controls log level in the wgpu example

## Testing
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_687ff644461083319dc0341e88c4554e