### PR TITLE
Fix tracing env-filter feature for wgpu example

### DIFF
--- a/examples/render-wgpu/Cargo.toml
+++ b/examples/render-wgpu/Cargo.toml
@@ -14,4 +14,4 @@ winit = { version = "0.29", features = ["rwh_05"] }
 glam = { version = "0.29.0", features = ["bytemuck"] }
 pollster = "0.3"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }


### PR DESCRIPTION
## Summary
- update tracing-subscriber dependency features for examples/render-wgpu

## Testing
- `cargo check --package render-wgpu --quiet`
- `cargo test --workspace --no-run --quiet` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687ff88177b0833198a44d3b3d944cd7