### PR TITLE
Respect RUST_LOG for debug output

### DIFF
--- a/examples/render-opengl/src/main.rs
+++ b/examples/render-opengl/src/main.rs
@@ -8,7 +8,7 @@ use inox2d_opengl::OpenglRenderer;
 
 use clap::Parser;
 use glam::Vec2;
-use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use winit::event::{ElementState, KeyEvent, WindowEvent};
 
@@ -33,9 +33,10 @@ struct Cli {
 fn main() -> Result<(), Box<dyn Error>> {
 	let cli = Cli::parse();
 
+	let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 	tracing_subscriber::registry()
 		.with(fmt::layer())
-		.with(LevelFilter::INFO)
+		.with(env_filter)
 		.init();
 
 	tracing::info!("Parsing puppet");

--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -3,7 +3,6 @@ use std::{error::Error, fs};
 
 use clap::Parser;
 use glam::Vec2;
-use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use wgpu::{Surface, SurfaceConfiguration};
@@ -97,9 +96,10 @@ async fn init_wgpu(
 async fn run() -> Result<(), Box<dyn Error>> {
 	let cli = Cli::parse();
 
+	let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 	tracing_subscriber::registry()
 		.with(fmt::layer())
-		.with(EnvFilter::from_default_env().add_directive(LevelFilter::INFO.into()))
+		.with(env_filter)
 		.init();
 
 	tracing::info!("Parsing puppet");


### PR DESCRIPTION
## Summary
- pipe RUST_LOG environment variable into the tracing subscriber so debug logs can be printed

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ffaaa92308331b80c8e68d7fa269d