### PR TITLE
Fix wgpu example clear

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -189,11 +189,12 @@ async fn run() -> Result<(), Box<dyn Error>> {
 				}
 			};
 			tracing::debug!("Acquired frame for drawing");
-			let view = frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
-			renderer.set_target_view(&view);
-			tracing::debug!("Rendering frame");
-			renderer.on_begin_draw(puppet);
-			renderer.draw(puppet);
+                        let view = frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
+                        renderer.set_target_view(&view);
+                        tracing::debug!("Rendering frame");
+                        renderer.clear();
+                        renderer.on_begin_draw(puppet);
+                        renderer.draw(puppet);
 			renderer.on_end_draw(puppet);
 			frame.present();
 			tracing::debug!("Frame presented");


### PR DESCRIPTION
## Summary
- add a `clear` method to `WgpuRenderer`
- clear the target before drawing frames in the wgpu example

## Testing
- `cargo build --examples`
- `./run_example.sh render-wgpu Aka` *(fails: neither `WAYLAND_DISPLAY` nor `DISPLAY` set)*

------
https://chatgpt.com/codex/tasks/task_e_687ffebb74b8833195e453b64b8b1f41