### PR TITLE
Fix render-wgpu example

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -192,6 +192,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
 			let view = frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
 			renderer.set_target_view(&view);
 			tracing::debug!("Rendering frame");
+			renderer.clear();
 			renderer.on_begin_draw(puppet);
 			renderer.draw(puppet);
 			renderer.on_end_draw(puppet);


### PR DESCRIPTION
## Summary
- clear the surface before drawing in `render-wgpu` example

## Testing
- `cargo test --all`
- `./run_example.sh render-wgpu Aka` *(fails: DISPLAY not set)*

------
https://chatgpt.com/codex/tasks/task_e_6880017311588331a614b1d99e27fa70