### PR TITLE
Fix uniform buffer alignment

### DIFF
--- a/inox2d-wgpu/src/lib.rs
+++ b/inox2d-wgpu/src/lib.rs
@@ -204,12 +204,12 @@ impl WgpuRenderer {
 			}],
 		});
 
-		let origin_buf = device.create_buffer(&wgpu::BufferDescriptor {
-			label: Some("inox2d_origin"),
-			size: std::mem::size_of::<[f32; 2]>() as u64,
-			usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-			mapped_at_creation: false,
-		});
+                let origin_buf = device.create_buffer(&wgpu::BufferDescriptor {
+                        label: Some("inox2d_origin"),
+                        size: 16,
+                        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                        mapped_at_creation: false,
+                });
 		let origin_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
 			label: Some("inox2d_origin_layout"),
 			entries: &[wgpu::BindGroupLayoutEntry {
@@ -357,12 +357,12 @@ impl WgpuRenderer {
 				count: None,
 			}],
 		});
-		let mask_buf = device.create_buffer(&wgpu::BufferDescriptor {
-			label: Some("inox2d_mask_buf"),
-			size: 4,
-			usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-			mapped_at_creation: false,
-		});
+                let mask_buf = device.create_buffer(&wgpu::BufferDescriptor {
+                        label: Some("inox2d_mask_buf"),
+                        size: 16,
+                        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                        mapped_at_creation: false,
+                });
 		let mask_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
 			label: Some("inox2d_mask_bg"),
 			layout: &mask_layout,

--- a/inox2d-wgpu/src/shaders/mask.wgsl
+++ b/inox2d-wgpu/src/shaders/mask.wgsl
@@ -6,7 +6,11 @@ struct VertexOut {
 @group(1) @binding(0) var samp: sampler;
 @group(1) @binding(1) var tex_albedo: texture_2d<f32>;
 
-struct MaskUniform { threshold: f32, };
+struct MaskUniform {
+    threshold: f32,
+    // Padding to satisfy 16-byte alignment requirements
+    _pad: vec3<f32>,
+};
 @group(2) @binding(0) var<uniform> mask: MaskUniform;
 
 @fragment


### PR DESCRIPTION
## Summary
- align uniform buffers to 16 bytes
- add explicit padding in `mask.wgsl`

## Testing
- `cargo check -q`

------
https://chatgpt.com/codex/tasks/task_e_68808d4f3cd08331aa7b4533a75249c2