### PR TITLE
Flush WGPU errors after each frame

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -192,14 +192,14 @@ async fn run() -> Result<(), Box<dyn Error>> {
 			let view = frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
 			renderer.set_target_view(&view);
 			tracing::debug!("Rendering frame");
-			renderer.clear();
-			renderer.on_begin_draw(puppet);
+                        renderer.on_begin_draw(puppet);
 			if std::env::var("INOX2D_DEBUG_DRAW").is_ok() {
 				renderer.draw_debug_rect();
 			}
-			renderer.draw(puppet);
-			renderer.on_end_draw(puppet);
-			frame.present();
+                        renderer.draw(puppet);
+                        renderer.on_end_draw(puppet);
+                        device.poll(wgpu::Maintain::Poll);
+                        frame.present();
 			tracing::debug!("Frame presented");
 			window.request_redraw();
 		}


### PR DESCRIPTION
## Summary
- fix render-wgpu example to work with latest renderer API
- flush WGPU errors immediately after submitting each frame
- keep uncaptured error logging active

## Testing
- `cargo check -p render-wgpu`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6880a750590883319ceddc534889dc3c