### PR TITLE
Fix wgpu mask uniform size

### DIFF
--- a/inox2d-wgpu/src/lib.rs
+++ b/inox2d-wgpu/src/lib.rs
@@ -358,12 +358,12 @@ impl WgpuRenderer {
 				count: None,
 			}],
 		});
-		let mask_buf = device.create_buffer(&wgpu::BufferDescriptor {
-			label: Some("inox2d_mask_buf"),
-			size: 16,
-			usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-			mapped_at_creation: false,
-		});
+                let mask_buf = device.create_buffer(&wgpu::BufferDescriptor {
+                        label: Some("inox2d_mask_buf"),
+                        size: 32,
+                        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                        mapped_at_creation: false,
+                });
 		let mask_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
 			label: Some("inox2d_mask_bg"),
 			layout: &mask_layout,

--- a/inox2d-wgpu/src/shaders/mask.wgsl
+++ b/inox2d-wgpu/src/shaders/mask.wgsl
@@ -8,7 +8,7 @@ struct VertexOut {
 
 struct MaskUniform {
     threshold: f32,
-    // Padding to satisfy 16-byte alignment requirements
+    // Padding to satisfy WGSL uniform alignment requirements
     _pad: vec3<f32>,
 };
 @group(2) @binding(0) var<uniform> mask: MaskUniform;


### PR DESCRIPTION
## Summary
- allocate 32 bytes for the mask uniform buffer
- clarify alignment comment in mask.wgsl

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_6880ac2bd61c83318883d1012535bfa5