### PR TITLE
Add alpha mode option to render-wgpu example

### DIFF
--- a/examples/render-wgpu/Cargo.toml
+++ b/examples/render-wgpu/Cargo.toml
@@ -8,7 +8,7 @@ common = { path = "../common" }
 inox2d = { path = "../../inox2d" }
 inox2d-wgpu = { path = "../../inox2d-wgpu" }
 
-clap = { version = "4.1.8", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive", "env"] }
 wgpu = "24"
 winit = { version = "0.29", features = ["rwh_05"] }
 glam = { version = "0.29.0", features = ["bytemuck"] }


### PR DESCRIPTION
## Summary
- allow selecting WGPU composite alpha mode via `--alpha-mode` or `INOX2D_ALPHA_MODE`
- warn when the chosen mode is unsupported or opaque on a transparent window
- enable `env` feature for clap

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6880d90c34bc83319d4a53289ecc3c4c