### PR TITLE
Fix wgpu crash when root list contained placeholders

### DIFF
--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -198,10 +198,10 @@ impl RenderCtx {
 		}
 
 		root_drawable_uuid_zsort_vec.sort_by(|a, b| a.1.total_cmp(&b.1).reverse());
+
+		self.root_drawables_zsorted.clear();
 		self.root_drawables_zsorted
-			.iter_mut()
-			.zip(root_drawable_uuid_zsort_vec.iter())
-			.for_each(|(old, new)| *old = new.0);
+			.extend(root_drawable_uuid_zsort_vec.iter().map(|(uuid, _)| *uuid));
 	}
 }
 


### PR DESCRIPTION
## Summary
- avoid leaving placeholder node IDs in `RenderCtx::root_drawables_zsorted`

## Testing
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_688107f75c908331b7dc1cd857cca855