### PR TITLE
Fix wgpu crash due to uninitialized drawable order

### DIFF
--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -113,14 +113,16 @@ impl RenderCtx {
 			}
 		}
 
-		let mut root_drawables_zsorted = Vec::new();
-		// similarly, populate later, before render
-		root_drawables_zsorted.resize(root_drawables_count, InoxNodeUuid(0));
+                let root_drawables_zsorted = Vec::with_capacity(root_drawables_count);
 
-		Self {
-			vertex_buffers,
-			root_drawables_zsorted,
-		}
+                let mut ctx = Self {
+                        vertex_buffers,
+                        root_drawables_zsorted,
+                };
+
+                ctx.update(nodes, comps);
+
+                ctx
 	}
 
 	/// Reset all `DeformStack`.


### PR DESCRIPTION
## Summary
- initialize `RenderCtx` with sorted root drawables

## Testing
- `cargo check -p inox2d`
- `cargo check -p inox2d-wgpu`
- `cargo check -p render-wgpu`


------
https://chatgpt.com/codex/tasks/task_e_68810b1b9ba883319becef43ea002602