### PR TITLE
Request first frame redraw

### DIFF
--- a/examples/render-wgpu/src/main.rs
+++ b/examples/render-wgpu/src/main.rs
@@ -165,8 +165,10 @@ async fn run() -> Result<(), Box<dyn Error>> {
 		.with_title("Render Inochi2D Puppet (WGPU)")
 		.build(&event_loop)?;
 
-	// Leak the window so the surface can outlive the original binding.
-	let window: &'static Window = Box::leak(Box::new(window));
+        // Leak the window so the surface can outlive the original binding.
+        let window: &'static Window = Box::leak(Box::new(window));
+        // Request the first frame
+        window.request_redraw();
 
 	let alpha_mode = cli.alpha_mode.map(Into::into);
 	let (surface, device, queue, mut surface_config) = init_wgpu(window, alpha_mode).await?;


### PR DESCRIPTION
## Summary
- ensure `examples/render-wgpu` schedules an initial redraw after the window is leaked

## Testing
- `cargo build -p render-wgpu`
- `cargo test --workspace --exclude examples --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6881120e409c83318671c97453f6e7cb