### PR TITLE
Initialize origin uniform buffer fully

### DIFF
--- a/inox2d-wgpu/src/lib.rs
+++ b/inox2d-wgpu/src/lib.rs
@@ -850,11 +850,11 @@ impl InoxRenderer for WgpuRenderer {
 
 		self.queue
 			.write_buffer(&self.transform_buf, 0, bytemuck::cast_slice(&arr));
-		let zero = [0.0f32, 0.0f32];
+		let zero = [0.0f32, 0.0f32, 0.0f32, 0.0f32];
 		self.queue
 			.write_buffer(&self.origin_buf, 0, bytemuck::cast_slice(&zero));
 		let origin = components.mesh.origin;
-		let origin_arr = [origin.x, origin.y];
+		let origin_arr = [origin.x, origin.y, 0.0, 0.0];
 		self.queue
 			.write_buffer(&self.origin_buf, 0, bytemuck::cast_slice(&origin_arr));
 
@@ -1048,7 +1048,7 @@ impl InoxRenderer for WgpuRenderer {
 		let arr = components.transform.to_cols_array();
 		self.queue
 			.write_buffer(&self.transform_buf, 0, bytemuck::cast_slice(&arr));
-		let zero = [0.0f32, 0.0f32];
+		let zero = [0.0f32, 0.0f32, 0.0f32, 0.0f32];
 		self.queue
 			.write_buffer(&self.origin_buf, 0, bytemuck::cast_slice(&zero));
 


### PR DESCRIPTION
## Summary
- ensure `origin_buf` writes use a full 16‑byte array

## Testing
- `cargo check -p inox2d-wgpu`


------
https://chatgpt.com/codex/tasks/task_e_68822edbcce483319e5523979b591074