### PR TITLE
Add WGPU headless renderer test

### DIFF
--- a/inox2d-wgpu/Cargo.toml
+++ b/inox2d-wgpu/Cargo.toml
@@ -20,6 +20,9 @@ features = ["serde"]
 
 [dev-dependencies]
 pollster = "0.4"
+image = "0.25"
+json = "0.12"
+futures = "0.3"
 
 [features]
 headless = ["winit"]


### PR DESCRIPTION
## Summary
- add new dev dependencies for tests
- create headless WGPU rendering test verifying output alpha

## Testing
- `cargo test --quiet -p inox2d-wgpu --features headless --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_6884a8a0f7588331896f95eab4c15e98