### PR TITLE
Add headless renderer test

### DIFF
--- a/inox2d-wgpu/src/headless.rs
+++ b/inox2d-wgpu/src/headless.rs
@@ -196,4 +196,107 @@ mod tests {
 
         assert!(has_alpha, "Rendered image should have non-zero alpha pixel");
     }
+
+    #[test]
+    fn render_simple_model_to_texture() {
+        #[cfg(all(unix, not(target_os = "macos")))]
+        if std::env::var("DISPLAY").is_err() && std::env::var("WAYLAND_DISPLAY").is_err() {
+            eprintln!("Skipping test: no display server available");
+            return;
+        }
+
+        let size = wgpu::Extent3d {
+            width: 2,
+            height: 2,
+            depth_or_array_layers: 1,
+        };
+
+        let (_surface, device, queue) =
+            pollster::block_on(init_headless_wgpu(size)).expect("init headless");
+
+        let img = ImageBuffer::<Rgba<u8>, _>::from_fn(1, 1, |_, _| Rgba([0, 255, 0, 255]));
+        let mut png = Vec::new();
+        PngEncoder::new(&mut png)
+            .write_image(img.as_raw(), 1, 1, ColorType::Rgba8.into())
+            .unwrap();
+        let tex = ModelTexture {
+            format: image::ImageFormat::Png,
+            data: Arc::from(png.into_boxed_slice()),
+        };
+
+        let puppet_json = r#"{
+            "meta": { "version": "1" },
+            "physics": { "pixelsPerMeter": 100.0, "gravity": 9.8 },
+            "param": [],
+            "nodes": {
+                "uuid": 0,
+                "name": "root",
+                "enabled": true,
+                "zsort": 0.0,
+                "transform": {
+                    "trans": [0.0,0.0,0.0],
+                    "rot": [0.0,0.0,0.0],
+                    "scale": [1.0,1.0],
+                    "pixel_snap": false
+                },
+                "lockToRoot": false,
+                "type": "Part",
+                "blend_mode": "Normal",
+                "textures": [0],
+                "mesh": {
+                    "verts": [0.0,0.0,1.0,0.0,1.0,1.0,0.0,1.0],
+                    "uvs":   [0.0,0.0,1.0,0.0,1.0,1.0,0.0,1.0],
+                    "indices": [0,1,2,0,2,3],
+                    "origin": [0.0,0.0]
+                },
+                "children": []
+            }
+        }"#;
+        let payload = json::parse(puppet_json).unwrap();
+        let mut puppet = Puppet::new_from_json(&payload).unwrap();
+        puppet.init_transforms();
+        puppet.init_rendering();
+
+        let model = Model {
+            puppet,
+            textures: vec![tex],
+            vendors: Vec::new(),
+        };
+
+        let mut renderer =
+            WgpuRenderer::new(device.clone(), queue.clone(), &model, wgpu::TextureFormat::Rgba8UnormSrgb)
+                .unwrap();
+        renderer.resize(size.width, size.height);
+
+        let puppet = &model.puppet;
+        renderer.on_begin_draw(puppet);
+        renderer.draw(puppet);
+        renderer.on_end_draw(puppet);
+        device.poll(wgpu::Maintain::Wait);
+
+        let bytes_per_row = ((4 * size.width + wgpu::COPY_BYTES_PER_ROW_ALIGNMENT - 1)
+            / wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+            * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: (bytes_per_row * size.height) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        renderer.copy_target_to_buffer(&mut encoder, &renderer.offscreen_texture, &buffer);
+        queue.submit(Some(encoder.finish()));
+
+        let slice = buffer.slice(..);
+        let (tx, rx) = oneshot::channel();
+        slice.map_async(wgpu::MapMode::Read, move |v| tx.send(v).unwrap());
+        device.poll(wgpu::Maintain::Wait);
+        pollster::block_on(rx).unwrap().unwrap();
+        let data = slice.get_mapped_range();
+        let has_alpha = data.chunks(4).any(|p| p[3] != 0);
+        drop(data);
+        buffer.unmap();
+
+        assert!(has_alpha, "Rendered image should have non-zero alpha pixel");
+    }
 }


### PR DESCRIPTION
## Summary
- add a new `render_simple_model_to_texture` test in `headless.rs`
- verify an offscreen texture rendered with `WgpuRenderer` contains a pixel with non-zero alpha

## Testing
- `cargo test -p inox2d-wgpu --features headless -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6884af129dec8331ac9a12483c2c1d7b