### PR TITLE
Synchronize stencil operations with OpenGL

### DIFF
--- a/inox2d-wgpu/src/lib.rs
+++ b/inox2d-wgpu/src/lib.rs
@@ -542,18 +542,18 @@ impl WgpuRenderer {
 				depth_write_enabled: false,
 				depth_compare: wgpu::CompareFunction::Always,
 				stencil: wgpu::StencilState {
-					front: wgpu::StencilFaceState {
-						compare: wgpu::CompareFunction::Always,
-						fail_op: wgpu::StencilOperation::Replace,
-						depth_fail_op: wgpu::StencilOperation::Replace,
-						pass_op: wgpu::StencilOperation::Replace,
-					},
-					back: wgpu::StencilFaceState {
-						compare: wgpu::CompareFunction::Always,
-						fail_op: wgpu::StencilOperation::Replace,
-						depth_fail_op: wgpu::StencilOperation::Replace,
-						pass_op: wgpu::StencilOperation::Replace,
-					},
+                                        front: wgpu::StencilFaceState {
+                                                compare: wgpu::CompareFunction::Always,
+                                                fail_op: wgpu::StencilOperation::Keep,
+                                                depth_fail_op: wgpu::StencilOperation::Keep,
+                                                pass_op: wgpu::StencilOperation::Replace,
+                                        },
+                                        back: wgpu::StencilFaceState {
+                                                compare: wgpu::CompareFunction::Always,
+                                                fail_op: wgpu::StencilOperation::Keep,
+                                                depth_fail_op: wgpu::StencilOperation::Keep,
+                                                pass_op: wgpu::StencilOperation::Replace,
+                                        },
 					read_mask: 0xff,
 					write_mask: 0xff,
 				},


### PR DESCRIPTION
## Summary
- match WGPU mask pipeline stencil operations with the OpenGL renderer

## Testing
- `cargo check --workspace` *(fails: rustc 1.75.0 is too old)*

------
https://chatgpt.com/codex/tasks/task_e_6884c162d7ac8331a6a7445de0d3e952